### PR TITLE
Add channel selection

### DIFF
--- a/RP/ChannelData.swift
+++ b/RP/ChannelData.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+// URL format constants
+let RP_API_URL_FORMAT = "https://api.radioparadise.com/api/nowplaying_list_v2022&chan=%ld&list_num=4"
+let RP_STREAM_URL_FORMAT = "http://stream.radioparadise.com/%@"
+
+// Channel structure
+struct Channel {
+    var title: String
+    var streamID: String
+    var channelID: Int
+
+    var streamURL: URL {
+        return URL(string: String(format: RP_STREAM_URL_FORMAT, streamID))!
+    }
+
+    var apiURL: URL {
+        return URL(string: String(format: RP_API_URL_FORMAT, channelID))!
+    }
+}
+
+// UserDefaults key for storing selected channel index
+let SELECTED_CHANNEL_KEY = "SelectedChannelIndex"
+
+//
+// The order in this array determines the order they will appear in the menu
+//
+let CHANNEL_DATA: [Channel] = [
+    // Main Mix
+    Channel(
+        title: "Main Mix",
+        streamID: "aac-320",
+        channelID: 0
+    ),
+    // Mellow Mix
+    Channel(
+        title: "Mellow Mix",
+        streamID: "mellow-320",
+        channelID: 1
+    ),
+    // Rock Mix
+    Channel(
+        title: "Rock Mix",
+        streamID: "rock-320",
+        channelID: 2
+    ),
+    // Global Mix
+    Channel(
+        title: "Global Mix",
+        streamID: "global-320",
+        channelID: 3
+    ),
+    // Beyond...
+    Channel(
+        title: "Beyond...",
+        streamID: "beyond-320",
+        channelID: 5
+    ),
+    // Serenity
+    Channel(
+        title: "Serenity",
+        streamID: "serenity",
+        channelID: 42
+    ),
+    // Radio 2050
+    Channel(
+        title: "Radio 2050",
+        streamID: "radio2050-320",
+        channelID: 2050
+    )
+]
+
+//
+// Current channel management
+//
+
+// Get the currently selected channel (defaults to Main Mix at index 0)
+func getCurrentChannel() -> Channel {
+    let selectedIndex = UserDefaults.standard.integer(forKey: SELECTED_CHANNEL_KEY)
+    if selectedIndex >= 0 && selectedIndex < CHANNEL_DATA.count {
+        return CHANNEL_DATA[selectedIndex]
+    }
+    return CHANNEL_DATA[0] // Default to Main Mix
+}
+
+// Set the currently selected channel
+func setCurrentChannel(index: Int) {
+    if index >= 0 && index < CHANNEL_DATA.count {
+        UserDefaults.standard.set(index, forKey: SELECTED_CHANNEL_KEY)
+    }
+}
+
+// Get the index of the currently selected channel
+func getCurrentChannelIndex() -> Int {
+    let selectedIndex = UserDefaults.standard.integer(forKey: SELECTED_CHANNEL_KEY)
+    if selectedIndex >= 0 && selectedIndex < CHANNEL_DATA.count {
+        return selectedIndex
+    }
+    return 0 // Default to Main Mix
+}
+
+// Current API URL and Stream URL based on selected channel
+var RP_API_URL: URL {
+    return getCurrentChannel().apiURL
+}
+
+var RP_STREAM_URL: URL {
+    return getCurrentChannel().streamURL
+}
+
+//
+// Get URL for channel (legacy function)
+//
+
+func getChannelURL(forChannel channel: Channel) -> URL? {
+    return channel.apiURL
+}

--- a/RP/ChannelData.swift
+++ b/RP/ChannelData.swift
@@ -1,7 +1,8 @@
 import Foundation
 
 // URL format constants
-let RP_API_URL_FORMAT = "https://api.radioparadise.com/api/nowplaying_list_v2022&chan=%ld&list_num=4"
+let bundleIdentifier = Bundle.main.bundleIdentifier ?? "dev.rybr.radioparadise"
+let RP_API_URL_FORMAT = "https://api.radioparadise.com/api/nowplaying_list_v2022?chan=%ld&list_num=4&player_id=\(bundleIdentifier)"
 let RP_STREAM_URL_FORMAT = "http://stream.radioparadise.com/%@"
 
 // Channel structure
@@ -100,18 +101,11 @@ func getCurrentChannelIndex() -> Int {
 }
 
 // Current API URL and Stream URL based on selected channel
-var RP_API_URL: URL {
+var currentChannelInfoURL: URL {
     return getCurrentChannel().apiURL
 }
 
-var RP_STREAM_URL: URL {
+var currentStreamURL: URL {
     return getCurrentChannel().streamURL
 }
 
-//
-// Get URL for channel (legacy function)
-//
-
-func getChannelURL(forChannel channel: Channel) -> URL? {
-    return channel.apiURL
-}

--- a/RP/RadioPlayer.swift
+++ b/RP/RadioPlayer.swift
@@ -3,9 +3,6 @@ import AudioStreaming
 import MediaPlayer
 import Cocoa
 
-let RP_STREAM_URL = URL(string: "http://stream.radioparadise.com/aac-320")!
-let RP_API_URL = URL(string: "https://api.radioparadise.com/api/nowplaying_list_v2022?mode=wip-channel&chan=0")!
-
 class RadioPlayer: NSObject, AudioPlayerDelegate {
     static let shared = RadioPlayer()
 
@@ -42,6 +39,22 @@ class RadioPlayer: NSObject, AudioPlayerDelegate {
     func stop() {
         timer?.invalidate()
         player?.stop()
+    }
+
+    func switchChannel() {
+        let wasPlaying = isPlaying
+
+        // Stop current playback
+        timer?.invalidate()
+        player?.stop()
+
+        // Only restart if we were playing before
+        if wasPlaying {
+            // Wait a moment for the stop to complete, then start with new channel
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                self.play()
+            }
+        }
     }
 
     var isPlaying: Bool {

--- a/RP/RadioPlayer.swift
+++ b/RP/RadioPlayer.swift
@@ -28,7 +28,7 @@ class RadioPlayer: NSObject, AudioPlayerDelegate {
     }
 
     func play() {
-        player?.play(url: RP_STREAM_URL)
+        player?.play(url: currentStreamURL)
         updateNowPlaying()
     }
 
@@ -121,7 +121,7 @@ class RadioPlayer: NSObject, AudioPlayerDelegate {
     }
 
     func updateNowPlaying() {
-        let task = URLSession.shared.dataTask(with: RP_API_URL) {
+        let task = URLSession.shared.dataTask(with: currentChannelInfoURL) {
             [weak self] data,
             response,
             error in


### PR DESCRIPTION
## Summary

Support all the main RP channels through a new menu item. Persists the last-selected channel in user defaults.

Fixes #1

## Checklist

- [X] This change will benefit the Radio Paradise community
- [X] I’ve read the [Contributing Guidelines](../CONTRIBUTING.md)
- [X] My changes are clear and focused on a single goal
- [X] I’ve tested on the latest macOS version I have access to
- [X] I’ve run any available build/lint steps locally
- [X] I’ve added/updated documentation if needed
