### PR TITLE
Fix the play/pause button in dark mode

### DIFF
--- a/RP/StatusMenuController.swift
+++ b/RP/StatusMenuController.swift
@@ -285,7 +285,7 @@ class StatusMenuController: NSObject {
         if let image = NSImage(systemSymbolName: imageName, accessibilityDescription: nil) {
             var config = NSImage.SymbolConfiguration(textStyle: .body,
                                                                  scale: .large)
-                config = config.applying(.init(paletteColors: [.black]))
+                config = config.applying(.init(paletteColors: [.labelColor]))
             button.image = image.withSymbolConfiguration(config)
         } else {
             // Fallback to text if system symbols aren't available


### PR DESCRIPTION
## Summary

The play/pause button stayed black in dark mode, since `.black` was set as the symbol palette color. It now uses `.labelColor` which auto-tints based on the light/dark configuration.

## Checklist

- [X] This change will benefit the Radio Paradise community
- [X] I’ve read the [Contributing Guidelines](../CONTRIBUTING.md)
- [X] My changes are clear and focused on a single goal
- [X] I’ve tested on the latest macOS version I have access to
- [X] I’ve run any available build/lint steps locally
- [X] I’ve added/updated documentation if needed
