### PR TITLE
Improve play/pause behavior, compressing menu down to an icon when paused

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@ Fixes #<issue_number> (if applicable)
 
 **What changed?**
   - 
-  
+
 **Why is this change needed?**
   - 
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Things that would be cool to add:
 
 - **Station selector**: Stream other stations on Radio Paradise. This means researching and managing the other song feeds as well.
 - **Limited bandwidth fallback**: The 320kbps stream is buttery but in case of slow connections, it might be helpful to downshift to lower-bandwidth streams.
-  
+
 ## License
 
 This project is licensed under the GPLv3 License - see the [LICENSE](LICENSE) file for details.

--- a/RP/AboutWindow.swift
+++ b/RP/AboutWindow.swift
@@ -32,7 +32,7 @@ class AboutWindow: NSObject, NSWindowDelegate {
 
         // Center the window on screen
         window.center()
-        
+
         // Configure the text view for links
         configureCreditsTextView()
 
@@ -40,7 +40,7 @@ class AboutWindow: NSObject, NSWindowDelegate {
         // Show the window
         window.makeKeyAndOrderFront(nil)
     }
-    
+
     // MARK: - Text View Configuration
 
     private func configureCreditsTextView() {
@@ -63,10 +63,10 @@ class AboutWindow: NSObject, NSWindowDelegate {
         creditsTextView.isAutomaticSpellingCorrectionEnabled = false
         creditsTextView.isAutomaticQuoteSubstitutionEnabled = false
         creditsTextView.isAutomaticDashSubstitutionEnabled = false
-        
+
         creditsTextView.textStorage?.setAttributedString(creditsText())
     }
-    
+
     private func creditsText() -> NSAttributedString {
         // Update version and credits label
         let _ = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0"
@@ -93,7 +93,7 @@ class AboutWindow: NSObject, NSWindowDelegate {
             .underlineStyle: NSUnderlineStyle.single.rawValue
         ]
 
-        attributedString.append(NSAttributedString(string: "Yo! Built with ❤️ by the Radio Paradise fans at ", attributes: baseAttributes))
+        attributedString.append(NSAttributedString(string: "Built with ❤️ by the Radio Paradise fans at ", attributes: baseAttributes))
 
         // Add rybr.dev link
         let rybrLink = NSAttributedString(string: "rybr.dev", attributes: linkAttributes.merging([.link: "https://rybr.dev"], uniquingKeysWith: { _, new in new }))

--- a/RP/ChannelData.swift
+++ b/RP/ChannelData.swift
@@ -2,7 +2,8 @@ import Foundation
 
 // URL format constants
 let bundleIdentifier = Bundle.main.bundleIdentifier ?? "dev.rybr.radioparadise"
-let RP_API_URL_FORMAT = "https://api.radioparadise.com/api/nowplaying_list_v2022?chan=%ld&list_num=4&player_id=\(bundleIdentifier)"
+let RP_NOW_PLAYING_URL_FORMAT = "https://api.radioparadise.com/api/now_playing?chan=%ld&player_id=\(bundleIdentifier)"
+let RP_NOW_PLAYING_DETAILS_URL_FORMAT = "https://api.radioparadise.com/api/nowplaying_list_v2022?chan=%ld&list_num=1&player_id=\(bundleIdentifier)"
 let RP_STREAM_URL_FORMAT = "http://stream.radioparadise.com/%@"
 
 // Channel structure
@@ -15,8 +16,12 @@ struct Channel {
         return URL(string: String(format: RP_STREAM_URL_FORMAT, streamID))!
     }
 
-    var apiURL: URL {
-        return URL(string: String(format: RP_API_URL_FORMAT, channelID))!
+    var nowPlayingAPIURL: URL {
+        return URL(string: String(format: RP_NOW_PLAYING_URL_FORMAT, channelID))!
+    }
+
+    var nowPlayingDetailsAPIURL: URL {
+        return URL(string: String(format: RP_NOW_PLAYING_DETAILS_URL_FORMAT, channelID))!
     }
 }
 
@@ -100,9 +105,13 @@ func getCurrentChannelIndex() -> Int {
     return 0 // Default to Main Mix
 }
 
-// Current API URL and Stream URL based on selected channel
-var currentChannelInfoURL: URL {
-    return getCurrentChannel().apiURL
+// Current API URLs and Stream URL based on selected channel
+var currentChannelNowPlayingURL: URL {
+    return getCurrentChannel().nowPlayingAPIURL
+}
+
+var currentChannelNowPlayingDetailsURL: URL {
+    return getCurrentChannel().nowPlayingDetailsAPIURL
 }
 
 var currentStreamURL: URL {

--- a/RP/MusicService.swift
+++ b/RP/MusicService.swift
@@ -221,10 +221,6 @@ class MusicService {
         if !self.hasAuthorization() {
             // No need to preload
             print("Not authorized to Apple Music yet")
-            DispatchQueue.main.async {
-                // We set this true because we want the user to be able to select it and start authorization
-                StatusMenuController.shared.updateSongPreloadStatus(isReady: true)
-            }
             return;
         }
         
@@ -233,10 +229,6 @@ class MusicService {
         // Skip if this song is already cached
         if songCache.value(forKey: key) != nil {
             print("Song already cached: \(currentSong.title) - \(currentSong.artist)")
-            // Notify that the song is ready
-            DispatchQueue.main.async {
-                StatusMenuController.shared.updateSongPreloadStatus(isReady: true)
-            }
             return
         }
 
@@ -254,10 +246,6 @@ class MusicService {
 
                     // Notify based on whether we found and cached the song
                     let isReady = song != nil
-                    DispatchQueue.main.async {
-                        StatusMenuController.shared.updateSongPreloadStatus(isReady: isReady)
-                    }
-
                     if isReady {
                         print("Preloaded song: \(title) - \(artist)")
                     } else {
@@ -268,10 +256,6 @@ class MusicService {
                 guard !Task.isCancelled else { return }
 
                 print("Failed to preload song: \(error)")
-                // On error, disable menu items
-                DispatchQueue.main.async {
-                    StatusMenuController.shared.updateSongPreloadStatus(isReady: false)
-                }
             }
         }
     }

--- a/RP/MusicService.swift
+++ b/RP/MusicService.swift
@@ -212,6 +212,10 @@ class MusicService {
 
         if !self.hasAuthorization() {
             // No need to preload
+            print("Not authorized to Apple Music yet")
+            DispatchQueue.main.async {
+                StatusMenuController.shared.updateSongPreloadStatus(isReady: true)
+            }
             return;
         }
         

--- a/RP/MusicService.swift
+++ b/RP/MusicService.swift
@@ -206,14 +206,23 @@ class MusicService {
 
     // MARK: - Preloading
 
-    func preloadSong(title: String, artist: String) {
+    func preloadCurrentSong() {
         // Cancel any existing preload task
         currentPreloadTask?.cancel()
+
+        let currentSong = RadioPlayer.shared.currentSongInfo()
+        if (currentSong.songId.isEmpty) {
+            return;
+        }
+
+        let artist = currentSong.artist
+        let title = currentSong.title
 
         if !self.hasAuthorization() {
             // No need to preload
             print("Not authorized to Apple Music yet")
             DispatchQueue.main.async {
+                // We set this true because we want the user to be able to select it and start authorization
                 StatusMenuController.shared.updateSongPreloadStatus(isReady: true)
             }
             return;
@@ -223,7 +232,7 @@ class MusicService {
 
         // Skip if this song is already cached
         if songCache.value(forKey: key) != nil {
-            print("Song already cached: \(title) - \(artist)")
+            print("Song already cached: \(currentSong.title) - \(currentSong.artist)")
             // Notify that the song is ready
             DispatchQueue.main.async {
                 StatusMenuController.shared.updateSongPreloadStatus(isReady: true)

--- a/RP/NotificationService.swift
+++ b/RP/NotificationService.swift
@@ -3,7 +3,7 @@ import UserNotifications
 
 class NotificationService: NSObject, UNUserNotificationCenterDelegate {
     static let shared = NotificationService()
-    
+
     public func setupNotifications() {
         UNUserNotificationCenter.current().delegate = self
         UNUserNotificationCenter.current().requestAuthorization(options: [.alert]) { granted, error in
@@ -12,7 +12,7 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
             }
         }
     }
-    
+
     func showNotification(title: String, body: String) {
         let content = UNMutableNotificationContent()
         content.title = title
@@ -24,7 +24,7 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
             }
         }
     }
-    
+
     // UNUserNotificationCenterDelegate method to show notifications when app is in foreground
     func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
         completionHandler([.banner])

--- a/RP/OverlayWindow.swift
+++ b/RP/OverlayWindow.swift
@@ -7,7 +7,7 @@ import Cocoa
 
 class OverlayWindow: NSWindow {
     override var canBecomeKey: Bool { return true }
-    
+
     static func create(withRect overlayRect: NSRect) -> OverlayWindow {
         let window = OverlayWindow(
             contentRect: overlayRect,

--- a/RP/RadioPlayer.swift
+++ b/RP/RadioPlayer.swift
@@ -2,168 +2,67 @@ import Foundation
 import AudioStreaming
 import MediaPlayer
 import Cocoa
+import LRUCache
 
 struct SongInfo {
     var artist: String = ""
     var title: String = ""
-    var songId: String = ""
-    var coverArt: NSImage? = nil
+    var songId: String? = nil
+    var coverArtUrl: String? = nil
 }
 
 class RadioPlayer: NSObject, AudioPlayerDelegate {
     static let shared = RadioPlayer()
 
     private var player: AudioPlayer?
-    private var timer: Timer?
-    private var pauseTimer: Timer?
-
-    private var songInfo: SongInfo = SongInfo()
-    private var originalSongInfo: SongInfo = SongInfo()
-    private var isPausedLongEnough = false
-    private var isSwitchingChannels = false
-    func currentSongInfo() -> SongInfo {
-        return songInfo
+    var isPlaying: Bool {
+        return [.playing, .bufferring, .running].contains(player?.state)
     }
+    
+    private var updateTimer: Timer?
+    private var pauseTimer: Timer?
+    
+    private(set) var currentSongInfo: SongInfo? = nil
+    private(set) var isSwitchingChannels = false
+    
+    let albumArtCache = LRUCache<String, NSImage>(countLimit: 3)
+    var visibleSongInfo: (SongInfo, NSImage) {
+        get {
+            let defaultImage = NSImage(named: "AppIcon")!
+            if let songInfo = currentSongInfo {
+                var coverArtImage = defaultImage
+                if let coverArtUrl = songInfo.coverArtUrl, let cachedCoverArtImage = self.albumArtCache.value(forKey: coverArtUrl) {
+                    coverArtImage = cachedCoverArtImage
+                }
+                return (songInfo, coverArtImage)
+            }
+            let currentChannelIndex = getCurrentChannelIndex()
+            let channelName = CHANNEL_DATA[currentChannelIndex].title
+            return (SongInfo(artist: "Radio Paradise", title: channelName), defaultImage)
+        }
+    }
+
+    //
+    // MARK: - Initialization
+    //
     
     private override init() {
         super.init()
         setupPlayer()
-    }
-
-    func togglePlayPause() {
-        if ![.playing, .bufferring].contains(player?.state) {
-            self.play()
-        } else {
-            self.pause()
-        }
-    }
-
-    func play() {
-        // Cancel pause timer and restore original song info if needed
-        pauseTimer?.invalidate()
-        pauseTimer = nil
-
-        if isPausedLongEnough {
-            isPausedLongEnough = false
-            songInfo = originalSongInfo
-        }
-
-        player?.play(url: currentStreamURL)
-        updateNowPlaying()
-    }
-
-    func pause() {
-        player?.pause()
-        startPauseTimer()
-    }
-
-    private func startPauseTimer() {
-        // Don't start pause timer if we're switching channels
-        guard !isSwitchingChannels else { return }
-
-        // Cancel any existing pause timer
-        pauseTimer?.invalidate()
-
-        // Store the original song info before we potentially modify it
-        originalSongInfo = songInfo
-        isPausedLongEnough = false
-
-        // Start a 15-second timer
-        pauseTimer = Timer.scheduledTimer(withTimeInterval: 15.0, repeats: false) { [weak self] _ in
-            self?.handleLongPause()
-        }
-    }
-
-    private func handleLongPause() {
-        guard !isPlaying else { return }
-
-        isPausedLongEnough = true
-
-        // Stop the song update timer since we're no longer showing real song info
-        timer?.invalidate()
-        timer = nil
-
-        // Get current channel name
-        let currentChannelIndex = getCurrentChannelIndex()
-        let channelName = CHANNEL_DATA[currentChannelIndex].title
-
-        // Update song info to show Radio Paradise and channel name
-        songInfo = SongInfo(
-            artist: "Radio Paradise",
-            title: channelName,
-            songId: "",
-            coverArt: NSImage(named: "AppIcon")
+        
+        NSWorkspace.shared.notificationCenter.addObserver(
+            self,
+            selector: #selector(systemDidWake),
+            name: NSWorkspace.didWakeNotification,
+            object: nil
         )
-
-        // Update the UI
-        updateUI()
     }
 
-    func stop() {
-        timer?.invalidate()
-        pauseTimer?.invalidate()
-        pauseTimer = nil
-        isPausedLongEnough = false
-        player?.stop()
+    deinit {
+        // Remove wake notification observer
+        NSWorkspace.shared.notificationCenter.removeObserver(self)
     }
-
-    func switchChannel() {
-        // Set flag to prevent pause animations during channel switch
-        isSwitchingChannels = true
-
-        // Stop current playback and cancel pause timer
-        timer?.invalidate()
-        pauseTimer?.invalidate()
-        pauseTimer = nil
-        isPausedLongEnough = false
-        player?.stop()
-
-        // Always start playing after switching channels
-        // Wait a moment for the stop to complete, then start with new channel
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-            self.play()
-            // Clear the flag after starting to play
-            self.isSwitchingChannels = false
-        }
-    }
-
-    var isPlaying: Bool {
-        return [.playing, .bufferring, .running].contains(player?.state)
-    }
-
-    var isCurrentlySwitchingChannels: Bool {
-        return isSwitchingChannels
-    }
-
-    private func findCurrentlyPlayingSong(from songs: [[String: Any]]) -> [String: Any]? {
-        let currentTime = Date().timeIntervalSince1970
-
-        for song in songs {
-            guard let playTimeMillis = song["play_time"] as? TimeInterval,
-                  let durationString = song["duration"] as? String,
-                  let durationMillis = Double(durationString) else {
-                continue
-            }
-
-            // Convert milliseconds to seconds
-            let playTime = playTimeMillis / 1000
-            let duration = durationMillis / 1000
-            let endTime = playTime + duration
-
-            // Check if current time falls within this song's play window
-            if currentTime >= playTime && currentTime < endTime {
-                print("Found currently playing song: \(song["title"] as? String ?? "Unknown") - \(song["artist"] as? String ?? "Unknown")")
-                print("Play time: \(playTime), Duration: \(duration), Current: \(currentTime)")
-                return song
-            }
-        }
-
-        // Fallback: if no song matches current time, return the first song
-        // This handles edge cases like network delays or timing mismatches
-        print("No song found for current time \(currentTime), falling back to first song")
-        return songs.first
-    }
-
+    
     private func setupPlayer() {
         player = AudioPlayer()
         player?.delegate = self
@@ -181,132 +80,295 @@ class RadioPlayer: NSObject, AudioPlayerDelegate {
             return .success
         }
     }
+    
+    //
+    // MARK: - System wake handler
+    //
 
-    func updateNowPlaying() {
-        let task = URLSession.shared.dataTask(with: currentChannelInfoURL) {
-            [weak self] data,
-            response,
-            error in
-            guard let self = self,
-                  let data = data,
-                  error == nil else {
-                print("Error fetching now playing info: \(error?.localizedDescription ?? "Unknown error")")
-                return
+    @objc private func systemDidWake() {
+        print("System woke from sleep - refreshing song data")
+
+        // If we're currently playing, refresh the song data immediately
+        if isPlaying {
+            updateNowPlaying()
+        }
+    }
+    
+    //
+    // MARK: - Player play/pause/stop
+    //
+    
+    func play() {
+        // Cancel pause timer
+        stopPauseTimer()
+        
+        player?.play(url: currentStreamURL)
+        updateNowPlaying()
+    }
+    
+    func pause() {
+        player?.pause()
+        startPauseTimer()
+    }
+    
+    func stop() {
+        stopUpdateTimer()
+        stopPauseTimer()
+        player?.stop()
+    }
+    
+    func togglePlayPause() {
+        if ![.playing, .bufferring].contains(player?.state) {
+            self.play()
+        } else {
+            self.pause()
+        }
+    }
+    
+    private func startPauseTimer() {
+        // Don't start pause timer if we're switching channels
+        guard !isSwitchingChannels else { return }
+        
+        DispatchQueue.main.async {
+            // Stop previous timers
+            self.stopPauseTimer()
+            
+            // Start a 15-second timer
+            self.pauseTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: false) { [weak self] _ in
+                self?.handleLongPause()
             }
+        }
+    }
+    
+    private func stopPauseTimer() {
+        DispatchQueue.main.async {
+            self.pauseTimer?.invalidate()
+            self.pauseTimer = nil
+        }
+    }
 
-            // Get current channel name
-            let currentChannelIndex = getCurrentChannelIndex()
-            let channelName = CHANNEL_DATA[currentChannelIndex].title
-
-            do {
-                if let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
-                    // Get artist, title, and song ID
-                    var artist = currentSong["artist"] as? String ?? "Radio Paradise"
-                    var title = currentSong["title"] as? String ?? channelName
-                    var songId = currentSong["song_id"] as? String ?? ""
-                    let coverArtUrl = currentSong["cover"] as? String ?? ""
-
-                    // Convert milliseconds to seconds
-                    let playTime = playTimeMillis / 1000
-                    let duration = (Double(durationMillis) ?? 0) / 1000
-
-                    // Calculate when the next song should start
-                    let nextSongTime = playTime + duration
-
-                    // Calculate how many seconds from now until the next song
-                    var onRadioBreak = false
-                    let currentTime = Date().timeIntervalSince1970
-                    let timeUntilNextSong = max(nextSongTime - currentTime + 5, 5)
-                    print("∆: \(nextSongTime - currentTime)")
-                    if (nextSongTime - currentTime < 0) {
-                        // We're probably in a commercial break. Set the title and refresh a little later.
-                        artist = "Radio Paradise"
-                        title = channelName
-                        songId = "__break"
-                        onRadioBreak = true
-                    }
-
-                    if (onRadioBreak) {
-                        DispatchQueue.main.async {
-                            self.songInfo.coverArt = NSImage(named: "AppIcon")
-                            self.updateUI()
-                        }
-                    } else if (coverArtUrl.isEmpty) {
-                        self.songInfo.coverArt = nil
-                        self.updateUI()
-                    } else {
-                        let url = URL(string: "https://img.radioparadise.com/\(coverArtUrl)")!
-                        let dataTask = URLSession.shared.dataTask(with: url) { [weak self] (data, _, _) in
-                            if let data = data, let image = NSImage(data: data) {
-                                self?.songInfo.coverArt = image
-                                self?.updateUI()
-                            }
-                        }
-                        dataTask.resume()
-                    }
-
-                    DispatchQueue.main.async {
-                        // Update stored song info
-                        if (songId != self.songInfo.songId) {
-                            self.songInfo = SongInfo(
-                                artist: artist,
-                                title: title,
-                                songId: songId,
-                                coverArt: nil
-                            )
-                            MusicService.shared.preloadCurrentSong()
-                        }
-
-                        self.updateUI()
-
-                        // Schedule the next update
-                        self.scheduleNextUpdate(in: timeUntilNextSong)
-                    }
+    private func handleLongPause() {
+        guard !isPlaying else { return }
+                
+        // Stop the song update timer since we're no longer showing real song info
+        stopUpdateTimer()
+        
+        // Wipe the current song
+        currentSongInfo = nil
+        
+        // Update the UI
+        updateUI()
+    }
+    
+    //
+    // MARK: - Channel switching
+    //
+    
+    func switchChannel() {
+        // Set flag to prevent pause animations during channel switch
+        isSwitchingChannels = true
+        
+        // Stop current playback and cancel pause timer
+        stopUpdateTimer()
+        stopPauseTimer()
+    
+        player?.stop()
+        
+        // Always start playing after switching channels
+        // Wait a moment for the stop to complete, then start with new channel
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            self.play()
+            // Clear the flag after starting to play
+            self.isSwitchingChannels = false
+        }
+    }
+    
+    //
+    // MARK: - Now Playing updates
+    //
+    // General flow:
+    // updateNowPlaying()
+    //    -> fetchNowPlayingInfo()
+    //       -> are we playing a song?
+    //          YES -> updateNowPlayingDetails()
+    //                 -> fetchNowPlayingDetails()
+    //    -> scheduleNextUpdate()
+    //
+    
+    func updateNowPlaying() {
+        print("Updating now playing data")
+        //
+        // This is an admittedly weird flow.
+        //   - It first calls /api/now_playing, which gives us an accurate picture of "what's streaming right now" --
+        //     it returns the *real-time* number of seconds until the next update, and *real-time* song info, which
+        //     will be empty if there is a radio break or conversation happening (this is particularly relevant on
+        //     Radio 2050). We update our artist, title, and album cover information from this.
+        //   - If there is a song currently playing, we call /api/nowplaying_v2022, which gives us the song ID (which
+        //     we need in order to generate the share link).
+        //   - tl;dr if the song ID was in /api/now_playing, it'd be a perfect endpoint :)
+        //
+        fetchNowPlayingInfo { result in
+            switch result {
+            case .success(let (songInfo, nextUpdateTime)):
+                self.updateCurrentSong(songInfo)
+                self.scheduleNextUpdate(in: nextUpdateTime)
+                if songInfo != nil {
+                    // If there is song info, we'll update with the additional details.
+                    // (Otherwise, we're likely on a radio break or there's other narration going on.)
+                    MusicService.shared.preloadCurrentSong()
+                    self.updateNowPlayingDetails()
                 }
-            } catch {
-                print("Error parsing JSON: \(error.localizedDescription)")
-
-                // If there's an error, try again in 30 seconds
+            case .failure:
                 DispatchQueue.main.async {
                     self.scheduleNextUpdate(in: 30)
                 }
             }
         }
-
-        task.resume()
     }
 
-    private func updateSystemNowPlaying() {
-        var nowPlayingInfo = [String: Any]()
-        nowPlayingInfo[MPMediaItemPropertyTitle] = self.songInfo.title
-        nowPlayingInfo[MPMediaItemPropertyArtist] = self.songInfo.artist
-        nowPlayingInfo[MPMediaItemPropertyMediaType] = MPMediaType.anyAudio.rawValue
-        nowPlayingInfo[MPNowPlayingInfoPropertyIsLiveStream] = true
-        nowPlayingInfo[MPNowPlayingInfoPropertyPlaybackRate] = NSNumber(value: self.player?.rate ?? 0.0)
-        if let coverArt = self.songInfo.coverArt {
-            nowPlayingInfo[MPMediaItemPropertyArtwork] = MPMediaItemArtwork(boundsSize: coverArt.size) { (
-                size: CGSize
-            ) -> NSImage in
-                return coverArt
+    private func fetchNowPlayingInfo(completion: @escaping (Result<(songInfo: SongInfo?, nextUpdateTime: TimeInterval), Error>) -> Void) {
+        let task = URLSession.shared.dataTask(with: currentChannelNowPlayingURL) { data, _, error in
+            guard let data = data, error == nil else {
+                print("Error fetching now playing info: \(error?.localizedDescription ?? "Unknown error")")
+                completion(.failure(error ?? NSError(domain: "RadioPlayer", code: -1, userInfo: [NSLocalizedDescriptionKey: "Unknown error"])))
+                return
+            }
+
+            do {
+                guard
+                    let currentSong = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                    let nextUpdateTime = currentSong["time"] as? TimeInterval
+                else {
+                    completion(.failure(NSError(domain: "RadioPlayer", code: -2, userInfo: [NSLocalizedDescriptionKey: "Invalid JSON structure"])))
+                    return
+                }
+
+                var songInfo: SongInfo? = nil
+                if let artist = currentSong["artist"] as? String, !artist.isEmpty, let title = currentSong["title"] as? String, !title.isEmpty {
+                    print("current: \(artist) - \(title)")
+                    // In this call, "cover" is a full URL
+                    let coverArtUrl = currentSong["cover"] as? String
+                    songInfo = SongInfo(artist: artist, title: title, coverArtUrl: coverArtUrl)
+                }
+                print("∆: \(nextUpdateTime)")
+                completion(.success((songInfo: songInfo, nextUpdateTime: nextUpdateTime)))
+
+            } catch {
+                print("Error parsing JSON: \(error.localizedDescription)")
+                completion(.failure(error))
             }
         }
-
-        MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
-        MPNowPlayingInfoCenter.default().playbackState = self.isPlaying ? .playing : .paused
+        task.resume()
+    }
+    
+    private func updateNowPlayingDetails() {
+        print("Updating now playing detailed data")
+        fetchNowPlayingDetails { result in
+            switch result {
+            case .success(let (songInfo)):
+                self.updateCurrentSong(songInfo)
+            case .failure:
+                DispatchQueue.main.async {
+                    self.scheduleNextUpdate(in: 30)
+                }
+            }
+        }
     }
 
+    private func fetchNowPlayingDetails(completion: @escaping (Result<SongInfo, Error>) -> Void) {
+        let task = URLSession.shared.dataTask(with: currentChannelNowPlayingDetailsURL) { data, _, error in
+            guard let data = data, error == nil else {
+                print("Error fetching now playing details: \(error?.localizedDescription ?? "Unknown error")")
+                completion(.failure(error ?? NSError(domain: "RadioPlayer", code: -1, userInfo: [NSLocalizedDescriptionKey: "Unknown error"])))
+                return
+            }
+
+            do {
+                guard
+                    let currentSongDetails = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                    let songs = currentSongDetails["song"] as? [[String: Any]],
+                    let currentSong = songs.count == 1 ? songs.first : nil,
+                    let songId = currentSong["song_id"] as? String,
+                    let artist = currentSong["artist"] as? String,
+                    let title  = currentSong["title"] as? String,
+                    let cover  = currentSong["cover"] as? String
+                else {
+                    completion(.failure(NSError(domain: "RadioPlayer", code: -2, userInfo: [NSLocalizedDescriptionKey: "Invalid JSON structure"])))
+                    return
+                }
+
+                // In this call, "cover" is a full URL
+                let coverArtUrl = "https://img.radioparadise.com/\(cover)";
+                let songInfo = SongInfo(artist: artist, title: title, songId: songId, coverArtUrl: coverArtUrl)
+                completion(.success(songInfo))
+            } catch {
+                print("Error parsing JSON: \(error.localizedDescription)")
+                completion(.failure(error))
+            }
+        }
+        task.resume()
+    }
+    
     private func scheduleNextUpdate(in seconds: TimeInterval) {
         // Cancel any existing timer
-        timer?.invalidate()
+        stopUpdateTimer()
 
-        // Schedule a new timer
-        timer = Timer.scheduledTimer(withTimeInterval: seconds, repeats: false) { [weak self] _ in
-            self?.updateNowPlaying()
+        // Schedule a new timer on the main queue to ensure it has an active run loop
+        // We add a 5sec fudge factor to account for crossfade/transitions
+        DispatchQueue.main.async {
+            self.updateTimer = Timer.scheduledTimer(withTimeInterval: seconds + 5.0, repeats: false) { timer in
+                self.updateNowPlaying()
+            }
         }
 
         print("Next song info update scheduled in \(Int(seconds)) seconds")
     }
+    
+    private func stopUpdateTimer() {
+        DispatchQueue.main.async {
+            self.updateTimer?.invalidate()
+            self.updateTimer = nil
+        }
+    }
+    
+    
+    //
+    // MARK: - UI Updates
+    //
+    
+    private func updateCurrentSong(_ songInfo: SongInfo?) {
+        currentSongInfo = songInfo
+        fetchCurrentCoverArt()
+        updateUI()
+    }
 
+    private func updateCurrentSong(artist: String, title: String, songId: String?, coverArtUrl: String?) {
+        let songInfo = SongInfo(
+            artist: artist,
+            title: title,
+            songId: songId,
+            coverArtUrl: coverArtUrl
+        )
+        updateCurrentSong(songInfo)
+    }
+    
+    private func updateSystemNowPlaying() {
+        let (songInfo, coverImage) = visibleSongInfo
+        var nowPlayingInfo = [String: Any]()
+        nowPlayingInfo[MPMediaItemPropertyTitle] = songInfo.title
+        nowPlayingInfo[MPMediaItemPropertyArtist] = songInfo.artist
+        nowPlayingInfo[MPMediaItemPropertyMediaType] = MPMediaType.anyAudio.rawValue
+        nowPlayingInfo[MPNowPlayingInfoPropertyIsLiveStream] = true
+        nowPlayingInfo[MPNowPlayingInfoPropertyPlaybackRate] = NSNumber(value: self.player?.rate ?? 0.0)
+        nowPlayingInfo[MPMediaItemPropertyArtwork] = MPMediaItemArtwork(boundsSize: coverImage.size) { (
+            size: CGSize
+        ) -> NSImage in
+            return coverImage
+        }
+        MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
+        MPNowPlayingInfoCenter.default().playbackState = self.isPlaying ? .playing : .paused
+    }
+    
     func updateUI() {
         let isPlaying = self.isPlaying
         DispatchQueue.main.async {
@@ -316,9 +378,36 @@ class RadioPlayer: NSObject, AudioPlayerDelegate {
             self.updateSystemNowPlaying()
         }
     }
+    
+    //
+    // MARK: Album art fetch
+    //
+    
+    private func fetchCurrentCoverArt() {
+        guard
+            let urlString = currentSongInfo?.coverArtUrl,
+            let url = URL(string: urlString)
+        else { return }
+        
+        if self.albumArtCache.value(forKey: urlString) != nil {
+            // We have a cached image, don't run the task
+            return
+        }
 
+        let task = URLSession.shared.dataTask(with: url) { data, _, _ in
+            guard let data = data, let image = NSImage(data: data) else { return }
+            self.albumArtCache.setValue(image, forKey: urlString)
+            DispatchQueue.main.async {
+                self.updateUI()
+            }
+        }
+        task.resume()
+    }
+
+    //
     // MARK: - AudioPlayerDelegate
-
+    //
+    
     func audioPlayerStateChanged(player: AudioPlayer, with newState: AudioPlayerState, previous: AudioPlayerState) {
         switch (newState) {
         case .ready:
@@ -332,13 +421,8 @@ class RadioPlayer: NSObject, AudioPlayerDelegate {
             fallthrough
         case .playing, .bufferring, .running:
             // Cancel pause timer when playing
-            pauseTimer?.invalidate()
-            pauseTimer = nil
-            if isPausedLongEnough {
-                isPausedLongEnough = false
-                songInfo = originalSongInfo
-            }
-            self.updateUI()
+            stopPauseTimer()
+            updateUI()
             break
         case .paused:
             if !isSwitchingChannels {
@@ -347,16 +431,14 @@ class RadioPlayer: NSObject, AudioPlayerDelegate {
             self.updateUI()
             break
         case .stopped:
-            pauseTimer?.invalidate()
-            pauseTimer = nil
-            isPausedLongEnough = false
-            self.updateUI()
+            stopPauseTimer()
+            updateUI()
             break
         default:
             break
         }
     }
-
+    
     func audioPlayerDidStartPlaying(player: AudioStreaming.AudioPlayer, with entryId: AudioStreaming.AudioEntryId) {}
     func audioPlayerDidFinishBuffering(player: AudioStreaming.AudioPlayer, with entryId: AudioStreaming.AudioEntryId) {}
     func audioPlayerDidFinishPlaying(player: AudioStreaming.AudioPlayer, entryId: AudioStreaming.AudioEntryId, stopReason: AudioStreaming.AudioPlayerStopReason, progress: Double, duration: Double) {}

--- a/RP/RadioPlayer.swift
+++ b/RP/RadioPlayer.swift
@@ -314,9 +314,10 @@ class RadioPlayer: NSObject, AudioPlayerDelegate {
         stopUpdateTimer()
 
         // Schedule a new timer on the main queue to ensure it has an active run loop
-        // We add a 5sec fudge factor to account for crossfade/transitions
+        // We add a 7.5sec fudge factor to account for crossfade/transitions. This is a total
+        // vibe check and will probably be off sometimes :)
         DispatchQueue.main.async {
-            self.updateTimer = Timer.scheduledTimer(withTimeInterval: seconds + 5.0, repeats: false) { timer in
+            self.updateTimer = Timer.scheduledTimer(withTimeInterval: seconds + 7.5, repeats: false) { timer in
                 self.updateNowPlaying()
             }
         }

--- a/RP/RadioPlayer.swift
+++ b/RP/RadioPlayer.swift
@@ -215,8 +215,8 @@ class RadioPlayer: NSObject, AudioPlayerDelegate {
                 if songInfo != nil {
                     // If there is song info, we'll update with the additional details.
                     // (Otherwise, we're likely on a radio break or there's other narration going on.)
-                    MusicService.shared.preloadCurrentSong()
                     self.updateNowPlayingDetails()
+                    MusicService.shared.preloadCurrentSong()
                 }
             case .failure:
                 DispatchQueue.main.async {

--- a/RP/RadioPlayer.swift
+++ b/RP/RadioPlayer.swift
@@ -134,7 +134,7 @@ class RadioPlayer: NSObject, AudioPlayerDelegate {
             self.stopPauseTimer()
             
             // Start a 15-second timer
-            self.pauseTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: false) { [weak self] _ in
+            self.pauseTimer = Timer.scheduledTimer(withTimeInterval: 15.0, repeats: false) { [weak self] _ in
                 self?.handleLongPause()
             }
         }

--- a/RP/RadioPlayer.swift
+++ b/RP/RadioPlayer.swift
@@ -194,16 +194,15 @@ class RadioPlayer: NSObject, AudioPlayerDelegate {
                 return
             }
 
+            // Get current channel name
+            let currentChannelIndex = getCurrentChannelIndex()
+            let channelName = CHANNEL_DATA[currentChannelIndex].title
+
             do {
                 if let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
-                   let songs = json["song"] as? [[String: Any]],
-                   let currentSong = findCurrentlyPlayingSong(from: songs),
-                   let playTimeMillis = currentSong["play_time"] as? TimeInterval,
-                   let durationMillis = currentSong["duration"] as? String {
-
                     // Get artist, title, and song ID
-                    var artist = currentSong["artist"] as? String ?? "Unknown Artist"
-                    var title = currentSong["title"] as? String ?? "Unknown Song"
+                    var artist = currentSong["artist"] as? String ?? "Radio Paradise"
+                    var title = currentSong["title"] as? String ?? channelName
                     var songId = currentSong["song_id"] as? String ?? ""
                     let coverArtUrl = currentSong["cover"] as? String ?? ""
 
@@ -222,8 +221,8 @@ class RadioPlayer: NSObject, AudioPlayerDelegate {
                     if (nextSongTime - currentTime < 0) {
                         // We're probably in a commercial break. Set the title and refresh a little later.
                         artist = "Radio Paradise"
-                        title = "Break"
-                        songId = ""
+                        title = channelName
+                        songId = "__break"
                         onRadioBreak = true
                     }
 

--- a/RP/StatusMenuController.swift
+++ b/RP/StatusMenuController.swift
@@ -77,7 +77,6 @@ class StatusMenuController: NSObject, NSMenuDelegate {
     private override init() {
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         statusItem.button?.title = "Radio Paradise"
-
         super.init()
     }
 
@@ -91,6 +90,7 @@ class StatusMenuController: NSObject, NSMenuDelegate {
     
     public func setupMenu() {
         let menu = NSMenu()
+        menu.autoenablesItems = false
 
         // Combined album art and now playing item
         let nowPlayingItem = NSMenuItem(title: "", action: nil, keyEquivalent: "")

--- a/RP/StatusMenuController.swift
+++ b/RP/StatusMenuController.swift
@@ -291,12 +291,13 @@ class StatusMenuController: NSObject {
         }
     }
     
-    func updateNowPlaying(isPaused: Bool) {
+    func updateNowPlaying() {
+        let isPlaying = RadioPlayer.shared.isPlaying
         let songInfo = RadioPlayer.shared.currentSongInfo()
         let songText = "\(songInfo.artist) - \(songInfo.title)"
 
         // Update the custom view with song information
-        let displayText = isPaused ? "\(songText) (Paused)" : songText
+        let displayText = !isPlaying ? "\(songText) (Paused)" : songText
         songInfoLabel?.stringValue = displayText
 
         // Initially disable Apple Music features until preloading completes
@@ -313,7 +314,6 @@ class StatusMenuController: NSObject {
         if !songInfo.songId.isEmpty {
             shareSongMenuItem?.isEnabled = true
             viewOnRadioParadiseMenuItem?.isEnabled = true
-            MusicService.shared.preloadSong(title: songInfo.title, artist: songInfo.artist)
         } else {
             shareSongMenuItem?.isEnabled = false
             viewOnRadioParadiseMenuItem?.isEnabled = false

--- a/RP/StatusMenuController.swift
+++ b/RP/StatusMenuController.swift
@@ -312,17 +312,19 @@ class StatusMenuController: NSObject {
 
         // Trigger preloading if this is a song
         if isSong {
+            shareSongMenuItem?.isEnabled = true
+            viewOnRadioParadiseMenuItem?.isEnabled = true
             let songInfo = RadioPlayer.shared.currentSongInfo
             MusicService.shared.preloadSong(title: songInfo.title, artist: songInfo.artist)
         } else {
+            shareSongMenuItem?.isEnabled = false
+            viewOnRadioParadiseMenuItem?.isEnabled = false
             updateSongPreloadStatus(isReady: false)
         }
     }
 
     func updateSongPreloadStatus(isReady: Bool) {
         addToPlaylistMenuItem?.isEnabled = isReady
-        shareSongMenuItem?.isEnabled = isReady
-        viewOnRadioParadiseMenuItem?.isEnabled = isReady
     }
 
     func updateAlbumArt() {


### PR DESCRIPTION
- Simplify menu handling (disable/enable the share and Apple Music options wholesale based on song info)
- On pause, don't leave the "illusion" of playing — instead compress the menu down, show "Paused" in the now playing view, and eventually (15sec) switch back to a generic channel view that does not update song/artist
 
## Checklist

- [X] This change will benefit the Radio Paradise community
- [X] I’ve read the [Contributing Guidelines](../CONTRIBUTING.md)
- [X] My changes are clear and focused on a single goal
- [X] I’ve tested on the latest macOS version I have access to
- [X] I’ve run any available build/lint steps locally
- [X] I’ve added/updated documentation if needed
