### PR TITLE
Add KFAT + rename stations, persist selection by channel ID (#12)

### DIFF
--- a/RP/ChannelData.swift
+++ b/RP/ChannelData.swift
@@ -25,8 +25,23 @@ struct Channel {
     }
 }
 
-// UserDefaults key for storing selected channel index
-let SELECTED_CHANNEL_KEY = "SelectedChannelIndex"
+// Stores the selected channel's stable Radio Paradise channel ID, so the menu
+// order can change without disturbing a saved selection. Older builds stored
+// the array index instead; that value is migrated once (see below).
+let SELECTED_CHANNEL_ID_KEY = "SelectedChannelID"
+private let LEGACY_SELECTED_CHANNEL_INDEX_KEY = "SelectedChannelIndex"
+
+// Legacy stored index -> channel ID, using the v1.0.x release order (the only
+// menu ordering that shipped with index-based persistence).
+private let LEGACY_INDEX_TO_CHANNEL_ID: [Int] = [
+    0,    // 0: Main Mix
+    1,    // 1: Mellow Mix
+    2,    // 2: Rock Mix   (now RockIt!)
+    3,    // 3: Global Mix (now The Globe)
+    5,    // 4: Beyond...
+    42,   // 5: Serenity
+    2050, // 6: Radio 2050
+]
 
 //
 // The order in this array determines the order they will appear in the menu
@@ -44,15 +59,15 @@ let CHANNEL_DATA: [Channel] = [
         streamID: "mellow-320",
         channelID: 1
     ),
-    // Rock Mix
+    // RockIt!
     Channel(
-        title: "Rock Mix",
+        title: "RockIt!",
         streamID: "rock-320",
         channelID: 2
     ),
-    // Global Mix
+    // The Globe
     Channel(
-        title: "Global Mix",
+        title: "The Globe",
         streamID: "global-320",
         channelID: 3
     ),
@@ -68,6 +83,12 @@ let CHANNEL_DATA: [Channel] = [
         streamID: "serenity",
         channelID: 42
     ),
+    // KFAT
+    Channel(
+        title: "KFAT",
+        streamID: "kfat-320",
+        channelID: 945
+    ),
     // Radio 2050
     Channel(
         title: "Radio 2050",
@@ -80,29 +101,50 @@ let CHANNEL_DATA: [Channel] = [
 // Current channel management
 //
 
-// Get the currently selected channel (defaults to Main Mix at index 0)
+private var defaultChannel: Channel { CHANNEL_DATA[0] }
+
+func channel(forID channelID: Int) -> Channel? {
+    return CHANNEL_DATA.first { $0.channelID == channelID }
+}
+
+// Resolves the stored selection to a channel ID, migrating a legacy index-based
+// value the first time it is seen. Returns nil when nothing has been stored.
+private func migratedSelectedChannelID() -> Int? {
+    let defaults = UserDefaults.standard
+
+    if defaults.object(forKey: SELECTED_CHANNEL_ID_KEY) != nil {
+        return defaults.integer(forKey: SELECTED_CHANNEL_ID_KEY)
+    }
+
+    // Migrate a legacy index-based selection, if present.
+    if defaults.object(forKey: LEGACY_SELECTED_CHANNEL_INDEX_KEY) != nil {
+        let legacyIndex = defaults.integer(forKey: LEGACY_SELECTED_CHANNEL_INDEX_KEY)
+        let migratedID = LEGACY_INDEX_TO_CHANNEL_ID.indices.contains(legacyIndex)
+            ? LEGACY_INDEX_TO_CHANNEL_ID[legacyIndex]
+            : defaultChannel.channelID
+        defaults.set(migratedID, forKey: SELECTED_CHANNEL_ID_KEY)
+        defaults.removeObject(forKey: LEGACY_SELECTED_CHANNEL_INDEX_KEY)
+        return migratedID
+    }
+
+    return nil
+}
+
+// Currently selected channel ID, defaulting to Main Mix.
+func getCurrentChannelID() -> Int {
+    if let storedID = migratedSelectedChannelID(), channel(forID: storedID) != nil {
+        return storedID
+    }
+    return defaultChannel.channelID
+}
+
 func getCurrentChannel() -> Channel {
-    let selectedIndex = UserDefaults.standard.integer(forKey: SELECTED_CHANNEL_KEY)
-    if selectedIndex >= 0 && selectedIndex < CHANNEL_DATA.count {
-        return CHANNEL_DATA[selectedIndex]
-    }
-    return CHANNEL_DATA[0] // Default to Main Mix
+    return channel(forID: getCurrentChannelID()) ?? defaultChannel
 }
 
-// Set the currently selected channel
-func setCurrentChannel(index: Int) {
-    if index >= 0 && index < CHANNEL_DATA.count {
-        UserDefaults.standard.set(index, forKey: SELECTED_CHANNEL_KEY)
-    }
-}
-
-// Get the index of the currently selected channel
-func getCurrentChannelIndex() -> Int {
-    let selectedIndex = UserDefaults.standard.integer(forKey: SELECTED_CHANNEL_KEY)
-    if selectedIndex >= 0 && selectedIndex < CHANNEL_DATA.count {
-        return selectedIndex
-    }
-    return 0 // Default to Main Mix
+func setCurrentChannel(channelID: Int) {
+    guard channel(forID: channelID) != nil else { return }
+    UserDefaults.standard.set(channelID, forKey: SELECTED_CHANNEL_ID_KEY)
 }
 
 // Current API URLs and Stream URL based on selected channel

--- a/RP/RadioPlayer.swift
+++ b/RP/RadioPlayer.swift
@@ -38,8 +38,7 @@ class RadioPlayer: NSObject, AudioPlayerDelegate {
                 }
                 return (songInfo, coverArtImage)
             }
-            let currentChannelIndex = getCurrentChannelIndex()
-            let channelName = CHANNEL_DATA[currentChannelIndex].title
+            let channelName = getCurrentChannel().title
             return (SongInfo(artist: "Radio Paradise", title: channelName), defaultImage)
         }
     }

--- a/RP/StatusMenuController.swift
+++ b/RP/StatusMenuController.swift
@@ -107,11 +107,12 @@ class StatusMenuController: NSObject, NSMenuDelegate {
         let channelMenuItem = NSMenuItem(title: "Channel", action: nil, keyEquivalent: "")
         let channelSubmenu = NSMenu()
 
-        for (index, channel) in CHANNEL_DATA.enumerated() {
+        let currentChannelID = getCurrentChannelID()
+        for channel in CHANNEL_DATA {
             let channelItem = NSMenuItem(title: channel.title, action: #selector(selectChannel(_:)), keyEquivalent: "")
             channelItem.target = self
-            channelItem.tag = index
-            channelItem.state = (index == getCurrentChannelIndex()) ? .on : .off
+            channelItem.tag = channel.channelID
+            channelItem.state = (channel.channelID == currentChannelID) ? .on : .off
             channelSubmenu.addItem(channelItem)
         }
 
@@ -250,10 +251,10 @@ class StatusMenuController: NSObject, NSMenuDelegate {
     }
 
     @objc private func selectChannel(_ sender: NSMenuItem) {
-        let selectedIndex = sender.tag
+        let selectedChannelID = sender.tag
 
         // Update the selected channel
-        setCurrentChannel(index: selectedIndex)
+        setCurrentChannel(channelID: selectedChannelID)
 
         // Update the menu checkmarks
         updateChannelMenuStates()
@@ -265,10 +266,10 @@ class StatusMenuController: NSObject, NSMenuDelegate {
         RadioPlayer.shared.switchChannel()
 
         // Show notification
-        let channel = CHANNEL_DATA[selectedIndex]
+        let selectedChannel = channel(forID: selectedChannelID) ?? getCurrentChannel()
         NotificationService.shared.showNotification(
             title: "Channel Changed",
-            body: "Now playing \(channel.title)"
+            body: "Now playing \(selectedChannel.title)"
         )
     }
 
@@ -278,9 +279,9 @@ class StatusMenuController: NSObject, NSMenuDelegate {
         // Find the channel submenu
         for item in menu.items {
             if item.title == "Channel", let submenu = item.submenu {
-                let currentIndex = getCurrentChannelIndex()
-                for (index, subItem) in submenu.items.enumerated() {
-                    subItem.state = (index == currentIndex) ? .on : .off
+                let currentID = getCurrentChannelID()
+                for subItem in submenu.items {
+                    subItem.state = (subItem.tag == currentID) ? .on : .off
                 }
                 break
             }


### PR DESCRIPTION
## Summary

Updates the channel list to reflect Radio Paradise's current stations (closes #12), and reworks how the selected channel is persisted so menu ordering is no longer bound to the original order.

### Station changes

| Change | Channel | Stream |
|--------|---------|--------|
| Rename **Rock Mix** → **RockIt!** | chan 2 | `rock-320` (unchanged) |
| Rename **Global Mix** → **The Globe** | chan 3 | `global-320` (unchanged) |
| Add **KFAT** (new) | chan 945 | `kfat-320` |

KFAT is placed after Serenity / before Radio 2050, matching RP's own `list_chan` ordering.

### Persist by channel ID (not array index)

Previously the selected channel was stored as the **array index** into `CHANNEL_DATA`, so reordering the menu (e.g. to slot KFAT in) would silently move existing users onto a different station. This PR persists the channel's stable RP channel ID under a new `UserDefaults` key `SelectedChannelID`.